### PR TITLE
Any URL can be used

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -139,11 +139,6 @@ class Coin:
     def sanitize_url(cls, url):
         # Remove surrounding ws and trailing /s
         url = url.strip().rstrip('/')
-        match = cls.RPC_URL_REGEX.match(url)
-        if not match:
-            raise CoinError(f'invalid daemon URL: "{url}"')
-        if match.groups()[1] is None:
-            url = f'{url}:{cls.RPC_PORT:d}'
         if not url.startswith(('http://', 'https://')):
             url = f'http://{url}'
         return url + '/'
@@ -1268,6 +1263,7 @@ class Dogecoin(AuxPowMixin, Coin):
     TX_PER_BLOCK = 20
     REORG_LIMIT = 2000
     DESERIALIZER = lib_tx.DeserializerAuxPowSegWit
+    RPC_PORT = 22555
 
 
 class DogecoinTestnet(Dogecoin):


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->